### PR TITLE
Changed pronouns for correctness and inclusivity (more than 2 genders)

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -196,7 +196,7 @@ Hardening enables the following features:
 * Position Independent Executable
     Build position independent code to take advantage of Address Space Layout Randomization
     offered by some kernels. An attacker who is able to cause execution of code at an arbitrary
-    memory location is thwarted if he or she doesn't know where anything useful is located.
+    memory location is thwarted if they doesn't know where anything useful is located.
     The stack and heap are randomly located by default but this allows the code section to be
     randomly located as well.
 

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -81,7 +81,7 @@ private:
                     fAllOk &= fOk;
                     nTodo -= nNow;
                     if (nTodo == 0 && !fMaster)
-                        // We processed the last element; inform the master he or she can exit and return the result
+                        // We processed the last element; inform the master they can exit and return the result
                         condMaster.notify_one();
                 } else {
                     // first iteration


### PR DESCRIPTION
This is a followup to #5730

['He or she' doesn't cover all genders](http://en.wikipedia.org/wiki/Gender-neutral_pronoun).
